### PR TITLE
Change mainservice

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -19,7 +19,7 @@
     "endpoint": "http://rpcdaemon.erigon.dappnode:8545",
     "homepage": "https://github.com/ledgerwatch/erigon"
   },
-  "mainService": "rpcdaemon",
+  "mainService": "erigon",
   "license": "GLP-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Usually, the logs that the users want to check are the Erigon service logs, so it would be nice to change the main service in order to make it easier to check the logs on the UI. This change was proposed for users in the discord Erigon channel.