### PR TITLE
Bump to version v2.43.0 and removing externalcl flag

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -3,7 +3,7 @@
   "version": "0.1.8",
   "shortDescription": "Ethereum client on the efficiency frontier, written in Go",
   "description": "Erigon is a next generation Ethereum client that introduces several new concepts:\n\n* A modular client design, enabling parallelized development of the client\n\n* New (`flat`) model of storing Ethereum state, allowing a lower disk footprint\n\n* Preprocessing of data outside of the storage engine, making database write operations faster by a magnitude\n\n* Staged synchronization technique, allowing very fast synchronization",
-  "upstreamVersion": "v2.42.0",
+  "upstreamVersion": "v2.43.0",
   "upstreamRepo": "ledgerwatch/erigon",
   "upstreamArg": "UPSTREAM_VERSION",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v2.42.0
+        UPSTREAM_VERSION: v2.43.0
     ports:
       - "30405:30405/tcp"
       - "30405:30405/udp"

--- a/erigon/entrypoint.sh
+++ b/erigon/entrypoint.sh
@@ -83,5 +83,4 @@ exec erigon --datadir=${DATADIR} \
     --authrpc.jwtsecret=${JWT_PATH} \
     --authrpc.addr 0.0.0.0 \
     --authrpc.vhosts=* \
-    --externalcl \
     ${EXTRA_OPTs}


### PR DESCRIPTION
Removing this flag because it caused this error in Erigon's last version (2.43.0):
```{"error":{"name":"No DNP with ip 172.33.0.16","message":"No DNP with ip 172.33.0.16"}}Incorrect Usage: flag provided but not defined: -externalcl```