### PR TITLE
Add ws to manifest

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -38,6 +38,12 @@
       "description": "JSON RPC endpoint for Erigon mainnet",
       "serviceName": "erigon",
       "port": 8545
+    },
+    {
+      "name": "Erigon JSON RPC (WS)",
+      "description": "JSON RPC WebSocket endpoint for Erigon mainnet",
+      "serviceName": "erigon",
+      "port": 8545
     }
   ],
   "globalEnvs": [

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -43,7 +43,7 @@
       "name": "Erigon JSON RPC (WS)",
       "description": "JSON RPC WebSocket endpoint for Erigon mainnet",
       "serviceName": "erigon",
-      "port": 8545
+      "port": 8546
     }
   ],
   "globalEnvs": [


### PR DESCRIPTION
closes #148 

Added WS port to "exposable" field of this package's manifest. Following Erigon [documentation](https://github.com/ledgerwatch/erigon#rpc-ports), ws is enabled through `--ws` flag and shares default port 8545. We have flag already initialized in our [entrypoint.sh](https://github.com/dappnode/DAppNodePackage-erigon/blob/main/erigon/entrypoint.sh), so only updating the manifest was needed.

Edited manifest following nethermind example: https://github.com/dappnode/DAppNodePackage-chiado-Nethermind/blob/b40905cec3e997d6462b18c89a9c39c3b4741eb9/dappnode_package.json#L16