### PR TITLE
Set 8545 for HTTP and WS

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -43,7 +43,7 @@
       "name": "Erigon JSON RPC (WS)",
       "description": "JSON RPC WebSocket endpoint for Erigon mainnet",
       "serviceName": "erigon",
-      "port": 8546
+      "port": 8545
     }
   ],
   "globalEnvs": [


### PR DESCRIPTION
Erigon exposes by default the RPC API for both HTTP and WS in port 8545